### PR TITLE
Fix AppUpdater in Nougat(API level 24+)

### DIFF
--- a/appupdater/build.gradle
+++ b/appupdater/build.gradle
@@ -27,4 +27,6 @@ dependencies {
     api "com.android.support:appcompat-v7:$rootProject.ext.android_support_version"
     api "com.android.support:design:$rootProject.ext.android_support_version"
     api 'com.squareup.okhttp3:okhttp:3.10.0'
+    implementation 'com.tbruyelle.rxpermissions2:rxpermissions:0.9.5@aar'
+    implementation 'io.reactivex.rxjava2:rxjava:2.1.11'
 }

--- a/appupdater/src/main/AndroidManifest.xml
+++ b/appupdater/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.github.javiersantos.appupdater">
-    
+
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 </manifest>

--- a/appupdater/src/main/AndroidManifest.xml
+++ b/appupdater/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.github.javiersantos.appupdater">
-
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 </manifest>

--- a/appupdater/src/main/java/com/github/javiersantos/appupdater/AppUpdater.java
+++ b/appupdater/src/main/java/com/github/javiersantos/appupdater/AppUpdater.java
@@ -19,6 +19,8 @@ import com.github.javiersantos.appupdater.objects.GitHub;
 import com.github.javiersantos.appupdater.objects.Update;
 
 public class AppUpdater implements IAppUpdater {
+
+    public static final String PREF_CHECK_UPDATES = "pref_check_updates";
     private Context context;
     private LibraryPreferences libraryPreferences;
     private Display display;
@@ -30,6 +32,7 @@ public class AppUpdater implements IAppUpdater {
     private Boolean showAppUpdated;
     private String titleUpdate, descriptionUpdate, btnDismiss, btnUpdate, btnDisable; // Update available
     private String titleNoUpdate, descriptionNoUpdate; // Update not available
+    private String appId;
     private int iconResId;
     private UtilsAsync.LatestAppVersion latestAppVersion;
     private DialogInterface.OnClickListener btnUpdateClickListener, btnDismissClickListener, btnDisableClickListener;
@@ -46,6 +49,7 @@ public class AppUpdater implements IAppUpdater {
         this.duration = Duration.NORMAL;
         this.showEvery = 1;
         this.showAppUpdated = false;
+        this.appId = "";
         this.iconResId = R.drawable.ic_stat_name;
 
         // Dialog
@@ -307,6 +311,12 @@ public class AppUpdater implements IAppUpdater {
     }
 
     @Override
+    public AppUpdater setAppId(String appId) {
+        this.appId = appId;
+        return this;
+    }
+
+    @Override
     public AppUpdater setIcon(@DrawableRes int iconRes) {
         this.iconResId = iconRes;
         return this;
@@ -339,7 +349,7 @@ public class AppUpdater implements IAppUpdater {
                     if (UtilsLibrary.isAbleToShow(successfulChecks, showEvery)) {
                         switch (display) {
                             case DIALOG:
-                                final DialogInterface.OnClickListener updateClickListener = btnUpdateClickListener == null ? new UpdateClickListener(context, updateFrom, update.getUrlToDownload(), iconResId) : btnUpdateClickListener;
+                                final DialogInterface.OnClickListener updateClickListener = btnUpdateClickListener == null ? new UpdateClickListener(context, updateFrom, update.getUrlToDownload(), appId, iconResId) : btnUpdateClickListener;
                                 final DialogInterface.OnClickListener disableClickListener = btnDisableClickListener == null ? new DisableClickListener(context) : btnDisableClickListener;
 
                                 alertDialog = UtilsDisplay.showUpdateAvailableDialog(context, titleUpdate, getDescriptionUpdate(context, update, Display.DIALOG), btnDismiss, btnUpdate, btnDisable, updateClickListener, btnDismissClickListener, disableClickListener);

--- a/appupdater/src/main/java/com/github/javiersantos/appupdater/IAppUpdater.java
+++ b/appupdater/src/main/java/com/github/javiersantos/appupdater/IAppUpdater.java
@@ -347,6 +347,14 @@ public interface IAppUpdater {
     AppUpdater setButtonDoNotShowAgainClickListener(DialogInterface.OnClickListener clickListener);
 
     /**
+     * Sets the app id for file provider <br/>
+     *
+     * @param appId The id of the application
+     * @return this
+     */
+    AppUpdater setAppId(String appId);
+
+    /**
      * Sets the resource identifier for the small notification icon
      *
      * @param iconRes The id of the drawable item

--- a/appupdater/src/main/java/com/github/javiersantos/appupdater/LibraryPreferences.java
+++ b/appupdater/src/main/java/com/github/javiersantos/appupdater/LibraryPreferences.java
@@ -8,7 +8,6 @@ class LibraryPreferences {
     private SharedPreferences sharedPreferences;
     private SharedPreferences.Editor editor;
 
-    static final String KeyAppUpdaterShow = "prefAppUpdaterShow";
     static final String KeySuccessfulChecks = "prefSuccessfulChecks";
 
     public LibraryPreferences(Context context) {
@@ -17,11 +16,11 @@ class LibraryPreferences {
     }
 
     public Boolean getAppUpdaterShow() {
-        return sharedPreferences.getBoolean(KeyAppUpdaterShow, true);
+        return sharedPreferences.getBoolean(AppUpdater.PREF_CHECK_UPDATES, true);
     }
 
     public void setAppUpdaterShow(Boolean res) {
-        editor.putBoolean(KeyAppUpdaterShow, res);
+        editor.putBoolean(AppUpdater.PREF_CHECK_UPDATES, res);
         editor.commit();
     }
 

--- a/appupdater/src/main/java/com/github/javiersantos/appupdater/UpdateClickListener.java
+++ b/appupdater/src/main/java/com/github/javiersantos/appupdater/UpdateClickListener.java
@@ -1,11 +1,16 @@
 package com.github.javiersantos.appupdater;
 
+import android.Manifest;
+import android.app.Activity;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.preference.PreferenceManager;
 
 import com.github.javiersantos.appupdater.enums.UpdateFrom;
+import com.tbruyelle.rxpermissions2.RxPermissions;
 
 import java.net.URL;
+import java.util.function.Consumer;
 
 /**
  * Click listener for the "Update" button of the update dialog. <br/>
@@ -16,17 +21,31 @@ public class UpdateClickListener implements DialogInterface.OnClickListener {
     private final Context context;
     private final UpdateFrom updateFrom;
     private final URL apk;
+    private final String appId;
     private final int iconResId;
 
-    public UpdateClickListener(final Context context, final UpdateFrom updateFrom, final URL apk, final int iconResId) {
+    public UpdateClickListener(final Context context, final UpdateFrom updateFrom, final URL apk, final String appId, final int iconResId) {
         this.context = context;
         this.updateFrom = updateFrom;
         this.apk = apk;
+        this.appId = appId;
         this.iconResId = iconResId;
     }
 
     @Override
     public void onClick(final DialogInterface dialog, final int which) {
-        UtilsLibrary.goToUpdate(context, updateFrom, apk, iconResId);
+        if (context instanceof Activity) {
+            RxPermissions permissions = new RxPermissions((Activity) context);
+            permissions.request(Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                    .subscribe(new io.reactivex.functions.Consumer<Boolean>() {
+                                   @Override
+                                   public void accept(Boolean granted) throws Exception {
+                                       if (granted) {
+                                           UtilsLibrary.goToUpdate(context, updateFrom, apk, appId, iconResId);
+                                       }
+                                   }
+                               }
+                        );
+        }
     }
 }

--- a/appupdater/src/main/java/com/github/javiersantos/appupdater/UtilsLibrary.java
+++ b/appupdater/src/main/java/com/github/javiersantos/appupdater/UtilsLibrary.java
@@ -282,7 +282,7 @@ class UtilsLibrary {
         return intent;
     }
 
-    static void goToUpdate(Context context, UpdateFrom updateFrom, URL url, int iconResId) {
+    static void goToUpdate(Context context, UpdateFrom updateFrom, URL url, String appId, int iconResId) {
         /*
         Intent intent = intentToUpdate(context, updateFrom, url);
 
@@ -298,6 +298,7 @@ class UtilsLibrary {
         }
         */
         Intent intent = new Intent(context, AppUpdateService.class);
+        intent.putExtra(AppUpdateService.INTENT_EXTRA_APP_ID, appId);
         intent.putExtra(AppUpdateService.INTENT_EXTRA_FILE_URL, url.toString());
         intent.putExtra(AppUpdateService.INTENT_EXTRA_ICON_RES_ID, iconResId);
         intent.setAction(AppUpdateService.ACTION_START);
@@ -305,7 +306,7 @@ class UtilsLibrary {
     }
 
     static void goToUpdate(Context context, UpdateFrom updateFrom, URL url) {
-        goToUpdate(context, updateFrom, url, R.drawable.ic_stat_name);
+        goToUpdate(context, updateFrom, url, "", R.drawable.ic_stat_name);
     }
 
     static Boolean isAbleToShow(Integer successfulChecks, Integer showEvery) {

--- a/appupdater/src/main/java/com/github/javiersantos/appupdater/services/AppUpdateService.java
+++ b/appupdater/src/main/java/com/github/javiersantos/appupdater/services/AppUpdateService.java
@@ -120,10 +120,9 @@ public class AppUpdateService extends Service {
                     NotificationCompat.Builder downloadNotificationBuilder = getDownloadNotificationBuilder();
                     notificationManager.notify(TAG, NOTIFICATION_DOWNLOAD_ID, downloadNotificationBuilder.build());
                     File directory = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
-                    String appName = response.request().url().queryParameter(PARAM_VERSION);
-                    String filePath = String.format("%s/%s", directory.getAbsolutePath(), appName) + ".apk";
+                    String appName = response.request().url().queryParameter(PARAM_VERSION) + ".apk";
+                    String filePath = String.format("%s/%s", directory.getAbsolutePath(), appName);
                     File fileToBeDownloaded = new File(filePath);
-                    Log.i(TAG, "filePath : " + filePath);
                     try {
                         downloadFile(response, fileToBeDownloaded, downloadNotificationBuilder);
                         notificationManager.cancel(TAG, NOTIFICATION_DOWNLOAD_ID);
@@ -212,7 +211,6 @@ public class AppUpdateService extends Service {
             }
         }
 
-        Log.i(TAG, fileToBeDownloaded.getAbsolutePath());
         os.flush();
         os.close();
         is.close();


### PR DESCRIPTION
This PR resolves muclipse/omnitrack_android#30

Using `FileProvider` rather than just using `Uri.from(path)` to avoid `FileUriExposedException`.
It also implements permission check logic before `AppUpdateService` starts its job using `RxPermissions`.